### PR TITLE
updated rules format with basic frontmatter

### DIFF
--- a/.cursor/rules/api-step-guide.mdc
+++ b/.cursor/rules/api-step-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: API step http handler
+globs: 
+alwaysApply: false
+---
 # API Step Implementation Guide
 
 API Steps expose HTTP endpoints that act as entry points into your Motia workflow. They allow external systems to trigger events within your application.

--- a/.cursor/rules/common-pitfalls-guide.mdc
+++ b/.cursor/rules/common-pitfalls-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # Common Pitfalls and How to Avoid Them
 
 This guide highlights common mistakes when working with Motia and provides solutions to avoid them.

--- a/.cursor/rules/cron-step-guide.mdc
+++ b/.cursor/rules/cron-step-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: Cron timer for scheduled jobs
+globs: 
+alwaysApply: false
+---
 # Cron Step Implementation Guide
 
 Cron Steps allow you to schedule tasks to run at specified intervals using cron expressions. They're perfect for recurring tasks like data synchronization, report generation, or cleanup operations.

--- a/.cursor/rules/cursor-motia-guide.mdc
+++ b/.cursor/rules/cursor-motia-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # Motia Framework Guide for Cursor Agent
 
 This guide is specifically for the Cursor Agent to help users implement workflows, steps, and flows correctly using the Motia framework.

--- a/.cursor/rules/deployment-guide.mdc
+++ b/.cursor/rules/deployment-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
 # Deployment Guide
 
 This guide covers the best practices for preparing and deploying Motia applications to various environments.

--- a/.cursor/rules/error-handling-guide.mdc
+++ b/.cursor/rules/error-handling-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: Error handling, error types, retry strategies, alerting, dead letter queues
+globs: 
+alwaysApply: false
+---
 # Error Handling Guide
 
 Effective error handling is crucial for building robust Motia workflows. This guide covers best practices for handling errors within your steps and flows.

--- a/.cursor/rules/event-step-guide.mdc
+++ b/.cursor/rules/event-step-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: steps/**/*.ts
+alwaysApply: false
+---
 # Event Step Implementation Guide
 
 Event Steps are the most common step type in Motia. They react to subscribed events, process data, and emit new events.

--- a/.cursor/rules/flow-design-guide.mdc
+++ b/.cursor/rules/flow-design-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: testing and design for flows, topic naming, and multi-flow steps
+globs: 
+alwaysApply: false
+---
 # Flow Design Guide
 
 Flows in Motia organize steps into logical, understandable workflows. They provide structure, visualization, and context for your event-driven applications.

--- a/.cursor/rules/integration-patterns-guide.mdc
+++ b/.cursor/rules/integration-patterns-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: integration with external services, user interaction, cli, chat, system tools or other systems
+globs: 
+alwaysApply: false
+---
 # Integration Patterns Guide
 
 This guide covers common integration patterns for connecting Motia workflows with external systems, APIs, and services.

--- a/.cursor/rules/logging-debugging-guide.mdc
+++ b/.cursor/rules/logging-debugging-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: logging and debugging
+globs: 
+alwaysApply: false
+---
 # Logging and Debugging Guide
 
 Motia provides a comprehensive logging and debugging system to help monitor and troubleshoot your workflows. The logging system works across different runtime environments and languages.

--- a/.cursor/rules/motia-framework-overview.mdc
+++ b/.cursor/rules/motia-framework-overview.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # Motia Framework Overview
 
 Motia is a code-first framework designed to empower developers to build robust, scalable, and observable event-driven workflows. It supports JavaScript/TypeScript, Python, and Ruby.

--- a/.cursor/rules/noop-step-guide.mdc
+++ b/.cursor/rules/noop-step-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: steps/**/*.ts
+alwaysApply: false
+---
 # NOOP Step Implementation Guide
 
 NOOP (No Operation) Steps are special steps used to:

--- a/.cursor/rules/project-structure-guide.mdc
+++ b/.cursor/rules/project-structure-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # Project Structure Guide
 
 This guide outlines the recommended project structure for Motia applications to promote organization, maintainability, and scalability.

--- a/.cursor/rules/state-management-guide.mdc
+++ b/.cursor/rules/state-management-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # State Management Guide
 
 Motia provides a built-in state management system that allows you to store and retrieve data across steps in your workflows. This is crucial for maintaining context throughout a flow's execution.

--- a/.cursor/rules/step-implementation-guide.mdc
+++ b/.cursor/rules/step-implementation-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # Step Implementation Guide
 
 ## Step Configuration Properties

--- a/.cursor/rules/testing-guide.mdc
+++ b/.cursor/rules/testing-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: test utilities and how to test each step and flow
+globs: 
+alwaysApply: false
+---
 # Testing Guide
 
 This guide covers the best practices for testing Motia workflows, steps, and event handling logic.

--- a/.cursor/rules/topic-and-event-guide.mdc
+++ b/.cursor/rules/topic-and-event-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
 # Topic and Event Guide
 
 Events and Topics are the core communication mechanism in Motia. They enable steps to interact with each other in a loosely coupled, asynchronous manner.

--- a/.cursor/rules/ui-step-guide.mdc
+++ b/.cursor/rules/ui-step-guide.mdc
@@ -1,3 +1,8 @@
+---
+description: UI display for user
+globs: 
+alwaysApply: false
+---
 # UI Step Implementation Guide
 
 UI Steps allow you to create custom visual representations of your workflow steps in Motia Workbench. This enhances understanding and clarity of your workflows by providing tailored, context-aware visualizations.


### PR DESCRIPTION
cursor has updated its rules format. 

to comply with the new format, this PR simply: 
- moves the old *.md files to their equivalent *.mdc files.
- implements basic frontmatter for matching and applying rules based on context